### PR TITLE
chore: enforce LF line endings and commit prettier config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ logs
 .idea
 .vscode
 .npmrc
-.prettierrc
 .notes
 
 # Local env files

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` (`* text=auto eol=lf`) so future checkouts/commits normalize consistently instead of drifting to CRLF, which was making ~43 unrelated files show as "modified" in local working trees.
- Un-gitignores `.prettierrc` and commits a real config (registers `prettier-plugin-tailwindcss`), since formatting config previously only existed per-machine.

This is PR 1 of a 4-part plan (hygiene → Nuxt 4 + Nuxt UI v4 migration → routine dependency sweep → improvement chores). Landing this first keeps the migration PR's diff clean.

Note for anyone with local CRLF drift already on disk: after merging, run `git add --renormalize .` (or a fresh checkout) in your working copy to snap existing files back to LF — `.gitattributes` only governs new checkouts/commits, it doesn't retroactively fix files already on disk.

## Test plan
- [ ] `git status` clean on a fresh clone/checkout
- [ ] `npx prettier --check .` picks up `.prettierrc.json` and the tailwind plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)