### PR TITLE
Fix bookmarks page favicons using dead Clearbit Logo API

### DIFF
--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -89,6 +89,6 @@ function getHost(url: string) {
 
 function getThumbnail(url: string) {
   const host = getHost(url);
-  return `https://logo.clearbit.com/${host}`;
+  return `https://www.google.com/s2/favicons?sz=128&domain=${host}`;
 }
 </script>


### PR DESCRIPTION
Clearbit's logo.clearbit.com service is no longer available, so bookmark
avatars were broken. Switch to Google's favicon service instead.