### PR TITLE
fix: restore broken icons and images in production

### DIFF
--- a/app/components/Home/SocialLinks.vue
+++ b/app/components/Home/SocialLinks.vue
@@ -17,12 +17,14 @@
         <div
           class="flex-1 border-b border-dashed border-gray-300 group-hover:border-gray-700 dark:border-gray-800"
         ></div>
-        <UIcon
-          :name="link.icon"
-          size="25"
-          mode="svg"
-          class="text-primary-400 group-hover:text-primary-600"
-        ></UIcon>
+        <client-only>
+          <UIcon
+            :name="link.icon"
+            size="25"
+            mode="svg"
+            class="text-primary-400 group-hover:text-primary-600"
+          ></UIcon>
+        </client-only>
       </NuxtLink>
     </div>
   </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,6 +12,28 @@ export default defineNuxtConfig({
 
   modules: ["@nuxt/ui", "@nuxt/icon", "@nuxt/image", "@nuxt/content"],
 
+  icon: {
+    // Default provider only resolves icons client-side (or via a live fetch
+    // to the public Iconify API during SSR/prerender for anything not in the
+    // small client bundle). Use the "server" provider so icons are resolved
+    // from a locally generated bundle instead.
+    provider: "server",
+    // "auto" also switches to fetching icons from a remote CDN at build time
+    // whenever the nitro preset name contains "cloudflare"/"edge"/"worker".
+    // This is a purely static build with no edge runtime, and the icon sets
+    // are already installed locally (@iconify-json/mage, @iconify-json/lucide),
+    // so force local bundling to avoid depending on that CDN at build time.
+    serverBundle: "local",
+  },
+
+  image: {
+    // This site is a fully static prerendered build (no server/edge functions),
+    // so @nuxt/image's IPX provider has nowhere to run at request time and the
+    // static prerenderer never generates the /_ipx/... files it points to.
+    // Serve images as-is instead of routing them through IPX.
+    provider: "none",
+  },
+
   app: {
     pageTransition: {
       name: "page",


### PR DESCRIPTION
The recent Nuxt UI v4 / @nuxt/image v2 upgrade broke every icon and
image on the site:

- @nuxt/icon's default provider fetches icons that aren't in the small
  client-side bundle from the public Iconify API at SSR/prerender time,
  and its "auto" server-bundle mode additionally switches to a remote
  CDN whenever the nitro preset name contains "cloudflare" (ours is
  "cloudflare_pages_static"). Force provider: "server" with
  serverBundle: "local" so icons resolve from the already-installed
  @iconify-json/mage and @iconify-json/lucide packages instead, and
  wrap the still-SSR-rendered social icons in <client-only> to match
  the pattern already used elsewhere (Navbar, ThemeToggle).

- @nuxt/image now auto-wraps the avatar (via Nuxt UI's Avatar) and all
  inline article images (via @nuxt/content's ProseImg) with NuxtImg,
  which rewrites their src to /_ipx/... URLs. This site is a fully
  static prerendered build with no server/edge functions, so nothing
  ever serves those IPX URLs and every image 404s. Set
  image.provider: "none" so images are served as the plain static
  files they already are.