### PR TITLE
fix: bundle icons client-side instead of via nonexistent server API

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,17 +13,32 @@ export default defineNuxtConfig({
   modules: ["@nuxt/ui", "@nuxt/icon", "@nuxt/image", "@nuxt/content"],
 
   icon: {
-    // Default provider only resolves icons client-side (or via a live fetch
-    // to the public Iconify API during SSR/prerender for anything not in the
-    // small client bundle). Use the "server" provider so icons are resolved
-    // from a locally generated bundle instead.
-    provider: "server",
-    // "auto" also switches to fetching icons from a remote CDN at build time
-    // whenever the nitro preset name contains "cloudflare"/"edge"/"worker".
-    // This is a purely static build with no edge runtime, and the icon sets
-    // are already installed locally (@iconify-json/mage, @iconify-json/lucide),
-    // so force local bundling to avoid depending on that CDN at build time.
-    serverBundle: "local",
+    // This is a purely static build with no server/edge runtime, so icons
+    // must be resolved entirely at build time with nothing fetched at
+    // request time. The "server" provider (previously used here) resolves
+    // icons via a Nitro API route (/api/_nuxt_icon/...), which doesn't
+    // exist in the static `dist/` output and 404s in production. Instead,
+    // bundle icons directly into the client JS at build time via
+    // clientBundle, so the <Icon>/<UIcon> components (all wrapped in
+    // <client-only> to avoid SSR/prerender-time resolution) render from
+    // local data with zero runtime requests. Icons are listed explicitly
+    // because some are chosen dynamically (e.g. ThemeToggle's ternary),
+    // which the automatic source scanner can miss.
+    clientBundle: {
+      scan: true,
+      icons: [
+        "mage:book-text-fill",
+        "mage:bookmark-fill",
+        "mage:folder-2-fill",
+        "mage:github",
+        "mage:home-fill",
+        "mage:linkedin",
+        "mage:medium",
+        "mage:moon-fill",
+        "mage:sun",
+        "mage:x",
+      ],
+    },
   },
 
   image: {


### PR DESCRIPTION
## Summary
- Root cause: `icon.provider: "server"` resolves icons at runtime via a Nitro API route (`/api/_nuxt_icon/...`), which doesn't exist in this static-only build (Cloudflare Pages, no server/edge functions) — confirmed the route is absent from `dist/` and every icon request 404s in production.
- Fix: switch to `@nuxt/icon`'s `clientBundle` so icon SVG data is inlined directly into the client JS at build time. Icons are listed explicitly (not relying solely on auto-scan) since some, like `ThemeToggle`'s sun/moon ternary, are chosen dynamically and can be missed by the source scanner.

## Test plan
- [x] `npm run generate` succeeds
- [x] Verified `dist/_nuxt/*.js` no longer references `/api/_nuxt_icon` as an active code path (provider is no longer `"server"`, so that branch is dead)
- [x] Verified icon SVG data (path/width/height for `mage:moon-fill`, `mage:sun`, etc.) is inlined directly in the client bundle
- [ ] Deploy and visually confirm icons render on brandonverzuu.com (navbar, theme toggle, social links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)