### PR TITLE
fix: stop cropping bookmark favicons to a circle

### DIFF
--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -11,6 +11,7 @@
             :src="getThumbnail(bookmark.url)"
             :alt="bookmark.label"
             size="lg"
+            :ui="{ root: 'rounded-md', image: 'rounded-none object-contain' }"
           />
           <div class="flex flex-col">
             <span class="text-gray-700 dark:text-gray-200">


### PR DESCRIPTION
UAvatar defaults to rounded-full + object-cover, which clipped non-square favicons into a circle and zoomed/cropped them. Override to a rounded-square box with object-contain so each favicon renders whole at a consistent size.