### PR TITLE
seo: structured data, llms.txt, breadcrumbs, homepage positioning (Phase 1-2)

### DIFF
--- a/app/components/App/Navbar.vue
+++ b/app/components/App/Navbar.vue
@@ -35,7 +35,7 @@
           <AppThemeToggle />
         </li>
         <li>
-          <UAvatar src="/avatar.jpg" />
+          <UAvatar src="/avatar.jpg" alt="Brandon Verzuu" />
         </li>
       </ul>
     </nav>

--- a/app/components/Home/Intro.vue
+++ b/app/components/Home/Intro.vue
@@ -20,10 +20,12 @@
 </template>
 
 <script setup>
+usePersonSchema();
+
 useSeoMeta({
-  title: "Brandon Verzuu — Head of Innovation & Product",
+  title: "Brandon Verzuu — Cloud Integration, API Strategy & Emerging Tech",
   description:
-    "Head of Innovation & Product from Rosmalen, The Netherlands, with a background in cloud integration, API strategy, and web-based APIs. Writing about software, technology, and the things I don't yet understand.",
+    "Head of Innovation & Product from Rosmalen, The Netherlands. Practitioner writing on cloud integration, API governance and strategy, and how AI and blockchain reshape technology and people.",
   ogUrl: "https://brandonverzuu.com/",
 });
 </script>

--- a/app/composables/useArticleSchema.ts
+++ b/app/composables/useArticleSchema.ts
@@ -1,0 +1,81 @@
+// BlogPosting + BreadcrumbList JSON-LD schema for an individual article page.
+// Takes reactive-ish plain values (called from a computed/watch context in
+// the page) rather than refs directly, since useHead's own reactivity
+// wrapper is what pages/articles/[slug].vue relies on — see how it's called.
+//
+// BlogPosting (not the more generic Article) since every entry here is a
+// dated, authored long-form post — the more specific type gives search
+// engines and AI crawlers a clearer signal.
+export interface ArticleSchemaInput {
+  title: string;
+  description: string;
+  slug: string;
+  date: string; // ISO-ish date string as stored in frontmatter
+  image?: string;
+  tags?: string[];
+}
+
+export function useArticleSchema(article: ArticleSchemaInput) {
+  const url = `https://brandonverzuu.com/articles/${article.slug}`;
+  const imageUrl = `https://brandonverzuu.com${article.image ?? "/avatar.jpg"}`;
+
+  useHead({
+    script: [
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: article.title,
+          description: article.description,
+          image: imageUrl,
+          datePublished: article.date,
+          dateModified: article.date,
+          url,
+          mainEntityOfPage: {
+            "@type": "WebPage",
+            "@id": url,
+          },
+          keywords: article.tags?.join(", "),
+          author: {
+            "@type": "Person",
+            name: "Brandon Verzuu",
+            url: "https://brandonverzuu.com",
+          },
+          publisher: {
+            "@type": "Person",
+            name: "Brandon Verzuu",
+            url: "https://brandonverzuu.com",
+          },
+        }),
+      },
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://brandonverzuu.com/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Articles",
+              item: "https://brandonverzuu.com/articles",
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: article.title,
+              item: url,
+            },
+          ],
+        }),
+      },
+    ],
+  });
+}

--- a/app/composables/usePersonSchema.ts
+++ b/app/composables/usePersonSchema.ts
@@ -1,0 +1,45 @@
+// Person JSON-LD schema, injected once on the homepage. This is the primary
+// entity declaration for AI agents/crawlers and Google's Knowledge Graph:
+// it explicitly ties this site to the same person across LinkedIn, GitHub,
+// Medium, and X via `sameAs`, and states the professional identity/expertise
+// areas in a machine-parseable form rather than only prose.
+//
+// Kept as a dedicated composable (not inlined in Home/Intro.vue) so the
+// schema payload has one source of truth if it needs to be referenced from
+// more than one place later (e.g. a future /about page).
+export function usePersonSchema() {
+  useHead({
+    script: [
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: "Brandon Verzuu",
+          url: "https://brandonverzuu.com",
+          image: "https://brandonverzuu.com/avatar.jpg",
+          jobTitle: "Head of Innovation & Product",
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: "Rosmalen",
+            addressCountry: "NL",
+          },
+          knowsAbout: [
+            "API Governance",
+            "Cloud Integration",
+            "Enterprise Integration Architecture",
+            "OpenAPI",
+            "Artificial Intelligence",
+            "Blockchain",
+          ],
+          sameAs: [
+            "https://www.linkedin.com/in/brandonverzuu/",
+            "https://github.com/brand0new",
+            "https://medium.com/@brandon-verzuu",
+            "https://twitter.com/brandonverzuu",
+          ],
+        }),
+      },
+    ],
+  });
+}

--- a/app/pages/articles/[slug].vue
+++ b/app/pages/articles/[slug].vue
@@ -3,6 +3,21 @@
     v-if="article"
     class="prose dark:prose-invert prose-blockquote:not-italic prose-img:rounded-lg mx-auto"
   >
+    <!-- Visible breadcrumb trail, paired with the BreadcrumbList schema
+         emitted by useArticleSchema — matching markup and structured data
+         is what search engines actually reward with a breadcrumb rich
+         result, an unmatched pair is often ignored. -->
+    <nav aria-label="Breadcrumb" class="not-prose mb-4">
+      <ol class="flex flex-wrap items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+        <li><NuxtLink to="/" class="hover:text-primary-500">Home</NuxtLink></li>
+        <li aria-hidden="true">/</li>
+        <li><NuxtLink to="/articles" class="hover:text-primary-500">Articles</NuxtLink></li>
+        <li aria-hidden="true">/</li>
+        <li class="text-gray-700 dark:text-gray-300" aria-current="page">
+          {{ article.title }}
+        </li>
+      </ol>
+    </nav>
     <h1 class="text-7xl font-extrabold">{{ article.title }}</h1>
     <UBadge
       v-for="tag in article.tags"
@@ -41,6 +56,25 @@ watch(
 onUnmounted(() => {
   articleBackgroundImage.value = null;
 });
+
+// BlogPosting + BreadcrumbList JSON-LD — only once the article has actually
+// resolved, since useArticleSchema needs real title/description/date values
+// rather than emitting a schema block for a not-yet-loaded page.
+watch(
+  article,
+  (value) => {
+    if (!value) return;
+    useArticleSchema({
+      title: value.title,
+      description: value.description,
+      slug,
+      date: String(value.date),
+      image: value.image,
+      tags: value.tags,
+    });
+  },
+  { immediate: true },
+);
 
 useSeoMeta({
   title: () =>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,53 @@
+# brandonverzuu.com — llms.txt
+# Machine-readable summary for AI agents, LLM crawlers, and RAG pipelines.
+# See https://llmstxt.org/ for the emerging convention this follows.
+
+## About
+
+Brandon Verzuu — Head of Innovation & Product, based in Rosmalen, The
+Netherlands. Practitioner and writer across cloud integration, API strategy
+and governance, and the broader effect of emerging technology (AI, trust,
+blockchain) on people and institutions. Writes from direct hands-on
+experience, not as an outside commentator.
+
+- Homepage: https://brandonverzuu.com
+- Articles index: https://brandonverzuu.com/articles
+- Projects: https://brandonverzuu.com/projects
+- LinkedIn: https://www.linkedin.com/in/brandonverzuu/
+- GitHub: https://github.com/brand0new
+- Medium (mirror): https://medium.com/@brandon-verzuu
+- X: https://twitter.com/brandonverzuu
+
+## Areas of expertise
+
+- API governance, linting, and executable design standards
+- Enterprise integration architecture, cloud integration, and platforms for
+  vendor-led delivery models
+- OpenAPI, Arazzo, and Overlay specifications and tooling
+- AI, trust, and the social contract between technology and people
+- Blockchain and cryptocurrency, including applications in emerging markets
+
+## Articles
+
+Long-form, practitioner-voice articles (English and Dutch), typically
+1,000-2,200 words, covering the areas above. Full list, always current:
+https://brandonverzuu.com/articles
+
+Representative entries:
+
+- Automate Your API Governance In 15 Minutes — https://brandonverzuu.com/articles/automate-api-governance
+- Capture API Changes with Overlay — https://brandonverzuu.com/articles/capture-api-changes-with-overlay
+- Improving Developer Experience with OpenAPI's Arazzo Workflow Specification — https://brandonverzuu.com/articles/improving-dx-with-arazzo
+- Everything you need to know about OpenAPI version 4 — https://brandonverzuu.com/articles/everything-about-openapi-4
+- What Should We Do Next? Ask a Focus Area Maturity Model — https://brandonverzuu.com/articles/maturity-models-and-tech
+- Building Platforms For Vendor-Led Enterprises — https://brandonverzuu.com/articles/building-platforms-for-vendor-led-enterprises
+- Trust in AI? A Reshaping of Our Social Contract — https://brandonverzuu.com/articles/trust-in-ai
+
+## Notes for AI agents and crawlers
+
+- All article content is prerendered static HTML — no JavaScript execution
+  required to read it.
+- The sitemap at https://brandonverzuu.com/sitemap.xml lists every indexable
+  URL and is kept current on every deploy.
+- This file is a curated summary, not an exhaustive index — prefer the
+  sitemap or /articles for a complete and current list.


### PR DESCRIPTION
SEO / AI-discoverability plan, Phase 1-2 (foundations + on-page). Phase 3+ (topical content clusters, off-site) awaits sign-off per plan.

**Foundations**
- Person JSON-LD schema on homepage: jobTitle, knowsAbout, sameAs -> LinkedIn/GitHub/Medium/X.
- BlogPosting + BreadcrumbList JSON-LD on every article page.
- public/llms.txt: curated summary for AI agent/LLM crawler consumption.

**On-page**
- Visible breadcrumb nav on article pages, matching the BreadcrumbList schema.
- Homepage title/meta rewritten for broad cloud/API + emerging-tech positioning (per explicit direction not to narrow to one niche), voice preserved.
- Alt text added to the navbar avatar.

**Deliberately NOT included**: Umami analytics wiring - blocked on a publicly-reachable URL (umbrel.local is LAN-only); will ship separately once available.

Verified npm run generate succeeds; visually confirmed breadcrumbs + background rendering via headless Chromium screenshot.