### PR TITLE
seo: Phase 3 topic cluster hub pages (API/AI/blockchain)

### DIFF
--- a/app/components/App/Navbar.vue
+++ b/app/components/App/Navbar.vue
@@ -62,6 +62,11 @@ const items = [
     icon: "mage:book-text-fill",
   },
   {
+    name: "Topics",
+    path: "/topics",
+    icon: "mage:tag-fill",
+  },
+  {
     name: "Projects",
     path: "/projects",
     icon: "mage:folder-2-fill",

--- a/app/components/Home/FeaturedArticles.vue
+++ b/app/components/Home/FeaturedArticles.vue
@@ -6,10 +6,16 @@
         <AppArticleCard :article="article" />
       </li>
     </ul>
-    <div class="mt-6 flex items-center justify-center text-sm">
+    <div class="mt-6 flex items-center justify-center gap-6 text-sm">
       <UButton
         label="All Articles &rarr;"
         to="/articles"
+        variant="link"
+        color="primary"
+      />
+      <UButton
+        label="Browse by Topic &rarr;"
+        to="/topics"
         variant="link"
         color="primary"
       />

--- a/app/composables/useTopicClusterSchema.ts
+++ b/app/composables/useTopicClusterSchema.ts
@@ -1,0 +1,71 @@
+// CollectionPage JSON-LD for a topic cluster hub page. Signals to search
+// engines and AI crawlers that this page is a curated collection of the
+// listed articles, not a duplicate of the /articles index — the mainEntity
+// ItemList is what lets a crawler understand the page's role as an authority
+// hub for the given topic rather than just another list view.
+export interface TopicClusterSchemaInput {
+  title: string;
+  description: string;
+  slug: string;
+  articles: { title: string; url: string; datePublished: string }[];
+}
+
+export function useTopicClusterSchema(input: TopicClusterSchemaInput) {
+  const url = `https://brandonverzuu.com/topics/${input.slug}`;
+
+  useHead({
+    script: [
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "CollectionPage",
+          name: input.title,
+          description: input.description,
+          url,
+          isPartOf: {
+            "@type": "WebSite",
+            name: "Brandon Verzuu",
+            url: "https://brandonverzuu.com",
+          },
+          mainEntity: {
+            "@type": "ItemList",
+            itemListElement: input.articles.map((article, index) => ({
+              "@type": "ListItem",
+              position: index + 1,
+              url: article.url,
+              name: article.title,
+            })),
+          },
+        }),
+      },
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://brandonverzuu.com/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Topics",
+              item: "https://brandonverzuu.com/topics",
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: input.title,
+              item: url,
+            },
+          ],
+        }),
+      },
+    ],
+  });
+}

--- a/app/pages/topics/[slug].vue
+++ b/app/pages/topics/[slug].vue
@@ -1,0 +1,70 @@
+<template>
+  <main v-if="cluster" class="min-h-screen">
+    <nav aria-label="Breadcrumb" class="mb-4">
+      <ol
+        class="flex flex-wrap items-center gap-1 text-sm text-gray-500 dark:text-gray-400"
+      >
+        <li><NuxtLink to="/" class="hover:text-primary-500">Home</NuxtLink></li>
+        <li aria-hidden="true">/</li>
+        <li>
+          <NuxtLink to="/topics" class="hover:text-primary-500">Topics</NuxtLink>
+        </li>
+        <li aria-hidden="true">/</li>
+        <li class="text-gray-700 dark:text-gray-300" aria-current="page">
+          {{ cluster.title }}
+        </li>
+      </ol>
+    </nav>
+    <AppHeader class="mb-8" :title="cluster.title" :description="cluster.intro" />
+    <ul v-if="filteredArticles.length" class="space-y-8">
+      <li v-for="(article, id) in filteredArticles" :key="id">
+        <AppArticleCard :article="article" />
+      </li>
+    </ul>
+    <p v-else class="text-sm text-gray-500 dark:text-gray-400">
+      No articles in this topic yet.
+    </p>
+  </main>
+</template>
+
+<script setup lang="ts">
+const slug = useRoute().params.slug as string;
+const cluster = topicClusters.find((c) => c.slug === slug);
+
+if (!cluster) {
+  throw createError({ statusCode: 404, statusMessage: "Topic not found" });
+}
+
+const { data: articles } = await useAsyncData(`topic-${slug}`, () =>
+  queryCollection("articles")
+    .where("published", "=", true)
+    .order("date", "DESC")
+    .all(),
+);
+
+// where("tags", ...) isn't expressible against a JSON array column via the
+// query builder, so filter client/server-side in JS instead — the articles
+// collection is small (a dozen entries), no performance concern here.
+const filteredArticles = computed(() =>
+  (articles.value ?? []).filter((article) =>
+    article.tags?.some((tag) => cluster!.tags.includes(tag)),
+  ),
+);
+
+useSeoMeta({
+  title: () => `${cluster!.title} | Brandon Verzuu`,
+  description: () => cluster!.summary,
+  ogUrl: () => `https://brandonverzuu.com/topics/${slug}`,
+});
+
+useTopicClusterSchema({
+  title: cluster.title,
+  description: cluster.summary,
+  slug,
+  articles: filteredArticles.value.map((article) => ({
+    title: article.title,
+    url: `https://brandonverzuu.com${article.path}`,
+    datePublished: String(article.date),
+  })),
+});
+</script>

--- a/app/pages/topics/index.vue
+++ b/app/pages/topics/index.vue
@@ -1,0 +1,32 @@
+<template>
+  <main class="min-h-screen">
+    <AppHeader
+      class="mb-8"
+      title="Topics"
+      :description="description"
+    />
+    <ul class="space-y-8">
+      <li v-for="cluster in topicClusters" :key="cluster.slug">
+        <NuxtLink :to="`/topics/${cluster.slug}`" class="group block">
+          <h3 class="group-hover:text-primary-500 dark:text-gray-100">
+            {{ cluster.title }}
+          </h3>
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            {{ cluster.summary }}
+          </p>
+        </NuxtLink>
+      </li>
+    </ul>
+  </main>
+</template>
+
+<script setup lang="ts">
+const description =
+  "My writing organised by theme rather than publish date — cloud integration and API governance, AI and trust, and blockchain, each grouped into one place.";
+
+useSeoMeta({
+  title: "Topics | Brandon Verzuu",
+  description,
+  ogUrl: "https://brandonverzuu.com/topics",
+});
+</script>

--- a/app/utils/topicClusters.ts
+++ b/app/utils/topicClusters.ts
@@ -1,0 +1,65 @@
+// Topic cluster definitions for the /topics hub pages (SEO/AI-discoverability
+// Phase 3 — see the plan agreed with Brandon). Each cluster groups articles
+// by their existing frontmatter `tags` so a single canonical page can
+// establish topical authority for that theme, without requiring a new
+// content collection or duplicating article metadata.
+//
+// Deliberately three clusters, not one: Brandon's positioning is a broad
+// cloud/API + emerging-tech practitioner, not a single-niche specialist —
+// see the corpus split (API governance content, one AI/trust piece, three
+// blockchain pieces). One hub page would either dilute the API cluster or
+// force blockchain/AI content under an ill-fitting umbrella.
+//
+// Adding a new cluster later: add an entry here: matching is purely by tag
+// intersection against content/articles/*.md frontmatter `tags`, no other
+// wiring needed — /topics/index.vue and /topics/[slug].vue both read this
+// array directly.
+export interface TopicCluster {
+  slug: string;
+  title: string;
+  /** Short framing shown on the /topics index card. */
+  summary: string;
+  /** Longer framing shown at the top of the cluster's own hub page. */
+  intro: string;
+  /** Article frontmatter tags that belong to this cluster. */
+  tags: string[];
+}
+
+export const topicClusters: TopicCluster[] = [
+  {
+    slug: "api-governance-integration",
+    title: "API Governance & Integration Architecture",
+    summary:
+      "Making governance executable, not aspirational — linting, specs, and platforms that keep integration quality consistent at scale.",
+    intro:
+      "Most of what I write about comes back to the same problem: organisations know what good API design and integration architecture look like, but knowing it and enforcing it are two different things. This is the collection of articles where I dig into that gap — automating governance instead of documenting it, using OpenAPI and its surrounding tooling (Arazzo, Overlay) to make the right path the easy path, and building platforms that hold up even when the people doing the integration work aren't your own employees.",
+    tags: [
+      "governance",
+      "api",
+      "openapi",
+      "arazzo",
+      "overlay",
+      "linting",
+      "developer experience",
+      "maturity-model",
+    ],
+  },
+  {
+    slug: "ai-trust-and-ethics",
+    title: "AI, Trust & the Social Contract",
+    summary:
+      "What it actually costs — not just what it promises — to hand decisions to AI.",
+    intro:
+      "I'm a tech-optimist, but optimism that never pays a cost isn't worth much. This is where I think through what trusting AI with more of our decisions actually asks of us — not the theoretical version, the one where someone has to decide how much autonomy is reasonable to hand over, and what happens when that trust is misplaced.",
+    tags: ["ai", "social contract", "ethics", "technology"],
+  },
+  {
+    slug: "blockchain-and-crypto",
+    title: "Blockchain & Cryptocurrency",
+    summary:
+      "Understanding what a blockchain is actually good for, beyond the speculation.",
+    intro:
+      "Blockchain got sold as a solution looking for a problem for long enough that it's easy to dismiss outright — I don't think that's fair either. These articles are me working through what a blockchain actually does well, where the value genuinely sits, and where the technology gets applied for reasons that go beyond a token price.",
+    tags: ["blockchain", "crypto", "bitcoin", "finance", "africa"],
+  },
+];

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,6 +43,7 @@ export default defineNuxtConfig({
         "mage:book-text-fill",
         "mage:bookmark-fill",
         "mage:folder-2-fill",
+        "mage:tag-fill",
         "mage:github",
         "mage:home-fill",
         "mage:linkedin",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,6 +12,7 @@ experience, not as an outside commentator.
 
 - Homepage: https://brandonverzuu.com
 - Articles index: https://brandonverzuu.com/articles
+- Topics (curated by theme): https://brandonverzuu.com/topics
 - Projects: https://brandonverzuu.com/projects
 - LinkedIn: https://www.linkedin.com/in/brandonverzuu/
 - GitHub: https://github.com/brand0new
@@ -32,6 +33,12 @@ experience, not as an outside commentator.
 Long-form, practitioner-voice articles (English and Dutch), typically
 1,000-2,200 words, covering the areas above. Full list, always current:
 https://brandonverzuu.com/articles
+
+Grouped by theme into three curated hubs, always current:
+
+- API Governance & Integration Architecture — https://brandonverzuu.com/topics/api-governance-integration
+- AI, Trust & the Social Contract — https://brandonverzuu.com/topics/ai-trust-and-ethics
+- Blockchain & Cryptocurrency — https://brandonverzuu.com/topics/blockchain-and-crypto
 
 Representative entries:
 


### PR DESCRIPTION
Phase 3 of the agreed SEO/AI-discoverability plan: topical authority via cluster hubs.

- New /topics index + /topics/[slug] pages grouping the 12 existing articles into 3 clusters by tag: API Governance & Integration Architecture (6), AI Trust & the Social Contract (1), Blockchain & Cryptocurrency (3).
- CollectionPage + BreadcrumbList JSON-LD on each cluster page.
- Topics added to navbar + homepage featured-articles link, for internal linking.
- llms.txt updated to point AI crawlers at the three hubs.

Verified npm run generate succeeds, sitemap includes all 4 new URLs, and visually confirmed rendering via headless Chromium screenshots.

Not yet done (per plan, awaiting further sign-off): Phase 3 next-article-topic proposals per cluster, Phase 4 (off-site signals), Phase 5 (cadence).