### PR TITLE
a11y: fix WCAG 2.1 AA issues found in accessibility audit

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,12 @@
 <template>
   <UApp>
     <div class="relative">
+      <a
+        href="#main-content"
+        class="focus:bg-primary-600 sr-only z-[60] rounded-md px-4 py-2 text-white focus:not-sr-only focus:fixed focus:top-2 focus:left-2"
+      >
+        Skip to content
+      </a>
       <ClientOnly>
         <HomeDitherBackground v-if="route.path === '/'" />
         <AppArticleDitherBackground
@@ -10,7 +16,7 @@
       </ClientOnly>
       <AppNavbar />
       <div class="h-32"></div>
-      <UContainer class="mx-auto max-w-xl lg:max-w-2xl">
+      <UContainer id="main-content" class="mx-auto max-w-xl lg:max-w-2xl">
         <NuxtPage />
       </UContainer>
     </div>

--- a/app/components/App/ArticleCard.vue
+++ b/app/components/App/ArticleCard.vue
@@ -39,9 +39,9 @@
           </span>
           {{ getReadableDate(article.date) }}
         </time>
-        <h3 class="group-hover:text-primary-400 text-white dark:text-white">
+        <h2 class="group-hover:text-primary-400 text-white dark:text-white">
           {{ article.title }}
-        </h3>
+        </h2>
         <p class="relative z-10 mt-2 text-sm text-gray-100 dark:text-gray-200">
           {{ article.description }}
         </p>

--- a/app/components/App/ProjectCard.vue
+++ b/app/components/App/ProjectCard.vue
@@ -6,14 +6,15 @@
     external
   >
     <div class="max-w-sm">
-      <h3
+      <h2
         :class="[
           'group-hover:text-primary-600',
           props.project.name.toLowerCase(),
         ]"
       >
         {{ props.project.name }}
-      </h3>
+        <span class="sr-only">(opens in new tab)</span>
+      </h2>
       <p class="text-sm text-gray-600 dark:text-gray-400">
         {{ props.project.description }}
       </p>

--- a/app/components/App/ThemeToggle.vue
+++ b/app/components/App/ThemeToggle.vue
@@ -15,6 +15,7 @@ const isDark = computed({
   <UTooltip text="Toggle theme" :ui="{ popper: { strategy: 'absolute' } }">
     <button
       class="hover:text-primary-500 dark:hover:text-primary-400 relative flex items-center justify-center px-3 py-4 transition"
+      :aria-pressed="isDark"
       @click="isDark = !isDark"
     >
       <ClientOnly>

--- a/app/components/App/UsesItem.vue
+++ b/app/components/App/UsesItem.vue
@@ -5,6 +5,7 @@
         class="group-hover:text-primary-600 text-base font-semibold text-gray-700 dark:text-gray-300"
       >
         {{ item.name }}
+        <span class="sr-only">(opens in new tab)</span>
       </p>
       <p class="text-sm text-gray-500">{{ item.description }}</p>
     </NuxtLink>

--- a/app/components/Home/Newsletter.vue
+++ b/app/components/Home/Newsletter.vue
@@ -13,14 +13,17 @@
     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
       Get notified when I publish something new, and unsubscribe at any time.
     </p>
-    <div class="mt-6 flex items-center gap-3">
+    <form class="mt-6 flex items-center gap-3" @submit.prevent>
+      <label for="newsletter-email" class="sr-only">Email address</label>
       <UInput
+        id="newsletter-email"
+        type="email"
         placeholder="Email Address"
         icon="i-heroicons-envelope"
         class="flex-1"
         size="lg"
       />
-      <UButton label="Join &rarr;" size="lg" color="black" />
-    </div>
+      <UButton type="submit" label="Join &rarr;" size="lg" color="black" />
+    </form>
   </div>
 </template>

--- a/app/components/Home/SocialLinks.vue
+++ b/app/components/Home/SocialLinks.vue
@@ -13,6 +13,7 @@
           class="group-hover:text-primary-600 text-sm text-gray-600 dark:text-gray-400"
         >
           {{ link.name }}
+          <span class="sr-only">(opens in new tab)</span>
         </p>
         <div
           class="flex-1 border-b border-dashed border-gray-300 group-hover:border-gray-700 dark:border-gray-800"

--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -17,7 +17,7 @@
             <span class="text-gray-700 dark:text-gray-200">
               {{ bookmark.label }}
             </span>
-            <span class="text-xs font-medium text-gray-400 dark:text-gray-600">
+            <span class="text-xs font-medium text-gray-500 dark:text-gray-400">
               {{ getHost(bookmark.url) }}
             </span>
           </div>


### PR DESCRIPTION
Fixes all 6 issues flagged in the accessibility audit (WCAG 2.1 AA baseline):

1. **Contrast fix**: bookmark host label was `text-gray-600` on black in dark mode (2.78:1, fails AA's 4.5:1). Now `text-gray-500`/`dark:text-gray-400` — 4.83:1 light, 8.27:1 dark.
2. **Heading hierarchy**: `ArticleCard`/`ProjectCard` used `h3` directly under a page's `h1`, skipping `h2` on `/articles`, `/projects`, `/topics/[slug]`. Both now render `h2` — clean h1→h2 sequence sitewide, no skipped ranks.
3. **Skip-to-content link** added in `app.vue` — visually hidden until keyboard-focused, jumps past the fixed navbar to `#main-content`.
4. **Newsletter email input** had no accessible name (placeholder-only, not a valid label substitute per WCAG 3.3.2). Added a visually-hidden `<label>`, wrapped in a real `<form>`.
5. **Theme toggle** now carries `:aria-pressed="isDark"` so its two-state nature is announced to assistive tech, not just conveyed visually.
6. **External links** already emit `rel="noopener noreferrer"` via `NuxtLink`'s `external` prop (verified, no fix needed) — added a visually-hidden "(opens in new tab)" span to `ProjectCard`, `UsesItem`, `SocialLinks` since there was no indication otherwise.

Verified `npm run generate` succeeds; confirmed heading counts / attributes directly in built HTML output; visual pass via headless Chromium screenshots (homepage, bookmarks, projects) confirms nothing broke visually.
