### PR TITLE
design: terracotta heading accent (light theme only) + fix dither contrast

### DIFF
--- a/app/components/App/ArticleDitherBackground.vue
+++ b/app/components/App/ArticleDitherBackground.vue
@@ -9,11 +9,22 @@
        gradient before the article body starts — same visual language as the
        homepage hero (start top, full width, fade going down), just a static
        image instead of drifting noise since the source is a pre-rendered
-       dither, not something we can regenerate per-frame in the browser. -->
+       dither, not something we can regenerate per-frame in the browser.
+
+       opacity-65 in light mode (vs. dark mode's 55%): the cover PNGs are
+       generated once with a single terracotta/porcelain-950 duotone tuned
+       for a dark page (scripts/generate-cover.mjs --light/--dark defaults).
+       Alpha-compositing that pair over a *white* light-theme background
+       washes both tones toward pastel gray — at the old 45% opacity the two
+       dot colors landed only ~1.6:1 apart and the pattern nearly vanished.
+       Raising light-mode opacity to 65% pushes contrast to ~2.3:1 — enough
+       to read clearly as texture behind the hero without regenerating
+       separate per-theme cover assets, and without competing with the
+       page-content legibility an even higher opacity (e.g. 85%) caused. -->
   <div
     ref="bgEl"
     aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-0 -z-10 w-full bg-cover bg-top opacity-45 dark:opacity-55"
+    class="pointer-events-none absolute inset-x-0 top-0 -z-10 w-full bg-cover bg-top opacity-65 dark:opacity-55"
     :style="{
       height: `${height}px`,
       backgroundImage: `url(${image})`,

--- a/app/components/Home/DitherBackground.vue
+++ b/app/components/Home/DitherBackground.vue
@@ -11,7 +11,7 @@
   <canvas
     ref="canvasEl"
     aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-0 -z-10 w-full opacity-45 dark:opacity-55"
+    class="pointer-events-none absolute inset-x-0 top-0 -z-10 w-full opacity-60 dark:opacity-55"
     :style="{ height: `${height}px` }"
   ></canvas>
 </template>
@@ -39,8 +39,18 @@ const height = ref(600);
 // Matches the article-cover duotone (public/css/main.css --color-terracotta /
 // --color-porcelain-950). Kept as plain hex here since this runs before any
 // CSS custom property lookup would be meaningful on a bare canvas.
+//
+// Dark-mode pair, composited at 55% opacity over a near-black page — this
+// combination reads with strong contrast there. Alpha-compositing the same
+// pair over a *white* page instead washes both tones toward pastel gray
+// (measured ~1.6:1 dot-to-dot contrast at the old 45% light-mode opacity —
+// the pattern nearly disappeared). NEAR_BLACK below is a warmer, near-black
+// "off" tone that stays dark even after alpha blending onto white, paired
+// with a higher light-mode opacity (see template above) so the pattern
+// stays legible against a white background.
 const LIGHT = [217, 122, 77]; // terracotta
 const DARK = [29, 46, 52]; // porcelain-950
+const NEAR_BLACK = [20, 15, 12]; // warm near-black "off" tone for light mode
 
 const CELL = 7; // px per dithered "pixel" — chunky, matches cover.png's pixelSize feel
 const FPS = 14; // fast enough to visibly read as motion, still deliberately steppy
@@ -101,8 +111,10 @@ function draw(canvas: HTMLCanvasElement) {
   ctx.clearRect(0, 0, cssWidth, cssHeight);
 
   const isDark = document.documentElement.classList.contains("dark");
-  const on = isDark ? LIGHT : DARK;
-  const off = isDark ? DARK : LIGHT;
+  // "on" pixel is terracotta in both themes; only the "off" tone and the
+  // overall opacity (set on the <canvas> element) change per theme.
+  const on = LIGHT;
+  const off = isDark ? DARK : NEAR_BLACK;
 
   for (let row = 0; row < rows; row++) {
     const bayerRow = BAYER_4X4[row % 4];

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -50,6 +50,13 @@
      used as the light tone in dithered article covers (see
      scripts/generate-cover.mjs) and echoed here for the no-cover fallback. */
   --color-terracotta: #d97a4d;
+
+  /* Darker terracotta for light-theme headings. Full-brightness terracotta
+     only hits ~3:1 contrast against a white page (fails WCAG AA for normal
+     text), so headings use this deepened shade in light mode only — dark
+     mode headings keep their previous (unstyled) color, unrelated to this
+     variable. See the html:not(.dark) h1-h6 rules below. */
+  --color-terracotta-heading: #8f431f;
 }
 
 .prose {
@@ -71,6 +78,51 @@ h5,
 h6 {
   font-family: "General Sans", sans-serif;
   font-weight: 600;
+}
+
+/* Heading accent color lives in @layer base so it loses to any Tailwind
+   utility class (e.g. ArticleCard.vue's `text-white` on cover-image
+   overlays) rather than winning the cascade just by being unlayered CSS —
+   Tailwind v4 utilities sit in @layer utilities, and unlayered rules beat
+   layered ones regardless of specificity, so without this the overlay
+   headings would incorrectly turn terracotta instead of staying white.
+   Scoped to `html:not(.dark)` (the color-mode module toggles a `.dark`
+   class on <html>) so dark theme keeps its previous, unstyled heading
+   color — this accent is light-theme only. */
+@layer base {
+  html:not(.dark) h1,
+  html:not(.dark) h2,
+  html:not(.dark) h3,
+  html:not(.dark) h4,
+  html:not(.dark) h5,
+  html:not(.dark) h6 {
+    color: var(--color-terracotta-heading);
+  }
+}
+
+/* Article pages wrap their content in Tailwind Typography's .prose, which
+   sets its own heading color via a `:where()`-wrapped selector. Neither
+   raising specificity (`.prose h1` vs. `.prose :where(h1)`) nor layer
+   placement reliably wins here: CSS layers resolve by LAYER ORDER first,
+   and Tailwind Typography's plugin apparently injects its own rules into a
+   layer position that beats a same-named `@layer components` block written
+   later in this file, regardless of the selector's specificity within that
+   layer (confirmed via CDP: `.prose h1` was present as a matched rule with
+   higher specificity than typography's `:where()` selector, yet computed
+   color still resolved to typography's gray-900). `!important` sidesteps
+   layer-order entirely and is the correct escape hatch for deliberately
+   overriding a third-party plugin's default here.
+
+   Light theme only (`html:not(.dark)`, matching the bare h1-h6 rule above)
+   — dark theme article headings keep Typography's previous default color,
+   unchanged. */
+html:not(.dark) .prose h1,
+html:not(.dark) .prose h2,
+html:not(.dark) .prose h3,
+html:not(.dark) .prose h4,
+html:not(.dark) .prose h5,
+html:not(.dark) .prose h6 {
+  color: var(--color-terracotta-heading) !important;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Light theme headings get a deepened terracotta accent (`#8f431f`, 6:1+ contrast on white). Dark theme headings are untouched — kept at their previous default color.
- Fixed light-theme dither contrast on both the homepage hero canvas and article cover backgrounds, which were washing out to near-invisible pastel gray when alpha-composited onto white. Dark mode dither is unchanged.

## Also found (not fixed here)
`AppArticleDitherBackground` never renders on any article detail page on `master` — confirmed on a clean checkout too. The `/articles` list thumbnails work fine, so it looks isolated to the `useArticleBackgroundImage`/`ClientOnly` wiring in `app.vue`/`[slug].vue`. Flagging as a follow-up, not addressed in this PR.

🤖 Generated with [Hermes](https://claude-code.nousresearch.com)