### PR TITLE
design: redesign /projects with bordered cards + dither hero; site-wide OG image fallback

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -46,11 +46,12 @@ const articleBackgroundImage = useArticleBackgroundImage();
 
 // HomeDitherBackground (the animated terracotta noise hero) is shared by
 // any top-level index/hub page, not just "/" — currently that's the
-// homepage and the /topics index. Both place a [data-dither-boundary]
+// homepage, /topics, and /projects. Each places a [data-dither-boundary]
 // marker in their own template so the canvas knows where to stop fading
 // regardless of which page rendered it (see DitherBackground.vue).
-const showHeroDitherBackground = computed(
-  () => route.path === "/" || route.path === "/topics",
+const HERO_DITHER_ROUTES = new Set(["/", "/topics", "/projects"]);
+const showHeroDitherBackground = computed(() =>
+  HERO_DITHER_ROUTES.has(route.path),
 );
 </script>
 

--- a/app/components/App/ProjectCard.vue
+++ b/app/components/App/ProjectCard.vue
@@ -1,32 +1,50 @@
 <template>
   <NuxtLink
-    class="group -m-2 flex items-end gap-4 rounded-lg p-2"
+    class="group block"
     :to="props.project.url"
     target="_blank"
     external
   >
-    <div class="max-w-sm">
-      <h2
-        :class="[
-          'group-hover:text-primary-600',
-          props.project.name.toLowerCase(),
-        ]"
-      >
-        {{ props.project.name }}
-        <span class="sr-only">(opens in new tab)</span>
-      </h2>
-      <p class="text-sm text-gray-600 dark:text-gray-400">
-        {{ props.project.description }}
-      </p>
-    </div>
-    <div
-      class="flex-1 border-b border-dashed border-gray-300 group-hover:border-gray-700 dark:border-gray-800"
-    ></div>
-    <UAvatar
-      :src="props.project.thumbnail"
-      size="md"
-      :alt="props.project.name"
-    />
+    <article
+      class="relative flex items-start gap-4 rounded-xl border border-gray-200 p-5 transition-colors group-hover:border-gray-300 dark:border-white/10 dark:group-hover:border-white/20"
+    >
+      <UAvatar
+        :src="props.project.thumbnail"
+        size="lg"
+        :alt="props.project.name"
+        class="flex-none"
+        :style="avatarStyle"
+      />
+      <div class="min-w-0 flex-1">
+        <div class="flex flex-wrap items-center gap-2">
+          <h2
+            class="group-hover:text-primary-600 dark:text-gray-100"
+            :style="titleStyle"
+          >
+            {{ props.project.name }}
+            <span class="sr-only">(opens in new tab)</span>
+          </h2>
+          <UBadge
+            v-if="props.project.status"
+            :label="props.project.status"
+            variant="subtle"
+            size="sm"
+            class="rounded-full"
+          />
+          <UBadge
+            v-if="props.project.opensource"
+            label="Open source"
+            variant="subtle"
+            color="neutral"
+            size="sm"
+            class="rounded-full"
+          />
+        </div>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          {{ props.project.description }}
+        </p>
+      </div>
+    </article>
   </NuxtLink>
 </template>
 
@@ -38,15 +56,29 @@ const props = defineProps({
       description: string;
       url: string;
       thumbnail: string;
+      status?: string;
+      opensource?: boolean;
+      accentColor?: string;
+      accentFont?: string;
     },
     required: true,
   },
 });
-</script>
 
-<style scoped>
-.abcdates {
-  font-family: "Telma";
-  color: #fe6e8b;
-}
-</style>
+// Per-project accent color/font, driven by content data rather than a
+// hardcoded per-slug class in this component's <style> block — the old
+// approach (e.g. `.abcdates { font-family: "Telma"; color: #fe6e8b }`)
+// required a code change for every new project. Falls back to no inline
+// override, letting the default text/hover colors and heading font apply.
+const titleStyle = computed(() => ({
+  ...(props.project.accentColor ? { color: props.project.accentColor } : {}),
+  ...(props.project.accentFont
+    ? { fontFamily: props.project.accentFont }
+    : {}),
+}));
+const avatarStyle = computed(() =>
+  props.project.accentColor
+    ? { backgroundColor: `${props.project.accentColor}1a` }
+    : {},
+);
+</script>

--- a/app/components/Home/Intro.vue
+++ b/app/components/Home/Intro.vue
@@ -27,5 +27,11 @@ useSeoMeta({
   description:
     "Head of Innovation & Product from Rosmalen, The Netherlands. Practitioner writing on cloud integration, API governance and strategy, and how AI and blockchain reshape technology and people.",
   ogUrl: "https://brandonverzuu.com/",
+  // Falls back to the avatar so social previews of the homepage itself
+  // resolve to a real file instead of 404ing — see articles/[slug].vue for
+  // the origin of this pattern, now applied site-wide on every page that
+  // has no page-specific hero image of its own.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 </script>

--- a/app/pages/articles/index.vue
+++ b/app/pages/articles/index.vue
@@ -23,5 +23,10 @@ useSeoMeta({
   title: "Articles | Brandon Verzuu",
   description,
   ogUrl: "https://brandonverzuu.com/articles",
+  // Falls back to the avatar so social previews resolve to a real file
+  // instead of 404ing — see articles/[slug].vue for the origin of this
+  // pattern, now applied to every index page that has no page-specific hero.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 </script>

--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -33,6 +33,11 @@ useSeoMeta({
   title: "Bookmarks | Brandon Verzuu",
   description,
   ogUrl: "https://brandonverzuu.com/bookmarks",
+  // Falls back to the avatar so social previews resolve to a real file
+  // instead of 404ing — see articles/[slug].vue for the origin of this
+  // pattern, now applied to every index page that has no page-specific hero.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 
 const bookmarks = [

--- a/app/pages/projects.vue
+++ b/app/pages/projects.vue
@@ -1,13 +1,16 @@
 <template>
-  <main>
+  <main class="min-h-screen">
     <AppHeader class="mb-12" title="Projects" :description="description" />
-    <div class="space-y-4">
-      <AppProjectCard
-        v-for="(project, id) in projects"
-        :key="id"
-        :project="project"
-      />
-    </div>
+    <!-- HomeDitherBackground (rendered in app.vue for this route) measures
+         this to know where to fully fade out — mirrors the homepage's and
+         /topics' own boundary marker so the terracotta hero always finishes
+         fading before the project cards start, regardless of viewport size. -->
+    <div data-dither-boundary></div>
+    <ul class="grid gap-4 sm:grid-cols-2">
+      <li v-for="(project, id) in projects" :key="id">
+        <AppProjectCard :project="project" />
+      </li>
+    </ul>
   </main>
 </template>
 
@@ -22,5 +25,11 @@ useSeoMeta({
   title: "Projects | Brandon Verzuu",
   description: description,
   ogUrl: "https://brandonverzuu.com/projects",
+  // No dedicated hero image for this index page (it's a list of projects,
+  // each with its own thumbnail) — fall back to the avatar so social
+  // previews still resolve to a real file rather than 404ing, matching the
+  // fallback articles/[slug].vue uses when an article has no cover.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 </script>

--- a/app/pages/topics/[slug].vue
+++ b/app/pages/topics/[slug].vue
@@ -69,6 +69,11 @@ useSeoMeta({
   title: () => `${cluster!.title} | Brandon Verzuu`,
   description: () => cluster!.summary,
   ogUrl: () => `https://brandonverzuu.com/topics/${slug}`,
+  // Falls back to the avatar so social previews resolve to a real file
+  // instead of 404ing — see articles/[slug].vue for the origin of this
+  // pattern, now applied to every index page that has no page-specific hero.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 
 useTopicClusterSchema({

--- a/app/pages/topics/index.vue
+++ b/app/pages/topics/index.vue
@@ -39,5 +39,10 @@ useSeoMeta({
   title: "Topics | Brandon Verzuu",
   description,
   ogUrl: "https://brandonverzuu.com/topics",
+  // Falls back to the avatar so social previews resolve to a real file
+  // instead of 404ing — see articles/[slug].vue for the origin of this
+  // pattern, now applied to every index page that has no page-specific hero.
+  ogImage: "https://brandonverzuu.com/avatar.jpg",
+  twitterCard: "summary_large_image",
 });
 </script>

--- a/content.config.ts
+++ b/content.config.ts
@@ -10,8 +10,23 @@ export default defineContentConfig({
         url: z.string(),
         description: z.string(),
         thumbnail: z.string(),
+        // Free-text status label shown as a badge on the card (e.g. "WIP",
+        // "Live", "Archived") — kept as a plain string rather than a fixed
+        // enum since this is a personal portfolio, not a product board, and
+        // new one-off statuses shouldn't require a schema change.
         status: z.string(),
         opensource: z.boolean(),
+        // Optional per-project accent color for the card's hover/icon
+        // treatment, as a CSS color value (hex/named). Replaces the old
+        // approach of hardcoding one-off classes per project slug in
+        // ProjectCard.vue (e.g. `.abcdates { color: #fe6e8b }`), which
+        // didn't scale past a couple of entries.
+        accentColor: z.string().optional(),
+        // Optional per-project display font for the title, e.g. "Telma" on
+        // Abcdates — a deliberate one-off decorative touch (see nuxt.config.ts
+        // fonts.families), not a general theming mechanism. Most projects
+        // should leave this unset and inherit the site's default heading font.
+        accentFont: z.string().optional(),
       }),
     }),
     articles: defineCollection({

--- a/content/projects/1.abcdates.json
+++ b/content/projects/1.abcdates.json
@@ -4,5 +4,7 @@
   "description": "Get ideas for dates based on the alphabet",
   "thumbnail": "/projects/abcdates.svg",
   "status": "WIP",
-  "opensource": false
+  "opensource": false,
+  "accentColor": "#fe6e8b",
+  "accentFont": "Telma"
 }


### PR DESCRIPTION
## What
- Restyles `ProjectCard.vue` to match `TopicCard.vue`'s bordered-card visual language (was a thin row with a dashed divider; now a proper card with border/hover state, status badge, open-source badge).
- Extends the `projects` content schema with `accentColor`/`accentFont`, replacing the hardcoded `.abcdates { font-family: "Telma"; color: #fe6e8b }` one-off CSS class so per-project styling is data-driven and scales.
- Adds the terracotta dither hero to `/projects` — it was the only top-level hub page (vs `/` and `/topics`) missing that treatment.
- **OG image audit**: none of `/`, `/articles`, `/bookmarks`, `/topics`, `/topics/[slug]`, or `/projects` set `ogImage` — every social share of those pages had no preview image at all. All now fall back to `/avatar.jpg`, mirroring the fallback pattern `articles/[slug].vue` already used.

## Content audit
Checked for unfinished/unpublished work: all 13 articles have `published: true`, no open PRs, no open `draft-article` issues. Nothing stuck in the pipeline.

## Verification
- `npm run generate` — clean build, all 48 routes prerendered, no errors (required a one-time `npm rebuild better-sqlite3` for the native module, unrelated to this change).
- Visually verified both desktop (1280px) and mobile (390px) via local preview — no overflow, cards stack cleanly, accent color/font correctly applied to Abcdates only.
- Confirmed `og:image` now present on every previously-missing page in the built HTML.

🤖 Generated by Hermes