### PR TITLE
design: extend terracotta dither hero to every page except article posts

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -44,14 +44,16 @@ useCanonical();
 const route = useRoute();
 const articleBackgroundImage = useArticleBackgroundImage();
 
-// HomeDitherBackground (the animated terracotta noise hero) is shared by
-// any top-level index/hub page, not just "/" — currently that's the
-// homepage, /topics, and /projects. Each places a [data-dither-boundary]
-// marker in their own template so the canvas knows where to stop fading
-// regardless of which page rendered it (see DitherBackground.vue).
-const HERO_DITHER_ROUTES = new Set(["/", "/topics", "/projects"]);
-const showHeroDitherBackground = computed(() =>
-  HERO_DITHER_ROUTES.has(route.path),
+// HomeDitherBackground (the animated terracotta noise hero) is now the
+// hero treatment for every page except individual article posts, which
+// keep their own per-article cover-derived background (see
+// AppArticleDitherBackground below) — that's a deliberate, content-specific
+// visual, not an omission. Every other route places a
+// [data-dither-boundary] marker in its own template so the canvas knows
+// where to stop fading regardless of which page rendered it (see
+// DitherBackground.vue).
+const showHeroDitherBackground = computed(
+  () => !route.path.startsWith("/articles/"),
 );
 </script>
 

--- a/app/components/Home/DitherBackground.vue
+++ b/app/components/Home/DitherBackground.vue
@@ -4,10 +4,10 @@
        in), so it spans edge-to-edge and sits behind AppNavbar (a `fixed`
        element that always paints above regardless of z-index here). Height
        is computed at runtime to reach the [data-dither-boundary] marker,
-       which any top-level hub page (currently the homepage and /topics)
-       places just before its "next section" starts, so the fade always
-       finishes before that section regardless of viewport size or content
-       reflow. -->
+       which every top-level page except individual article posts places
+       just before its "next section" starts (see app.vue), so the fade
+       always finishes before that section regardless of viewport size or
+       content reflow. -->
   <canvas
     ref="canvasEl"
     aria-hidden="true"

--- a/app/pages/articles/index.vue
+++ b/app/pages/articles/index.vue
@@ -1,6 +1,10 @@
 <template>
   <main class="min-h-screen">
     <AppHeader class="mb-8" title="Articles" :description="description" />
+    <!-- HomeDitherBackground (rendered in app.vue for this route) measures
+         this to know where to fully fade out — same boundary marker used by
+         every other top-level page (/, /topics, /projects, /bookmarks). -->
+    <div data-dither-boundary></div>
     <ul class="space-y-8">
       <li v-for="(article, id) in articles" :key="id">
         <AppArticleCard :article="article" />

--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -1,6 +1,10 @@
 <template>
-  <main>
+  <main class="min-h-screen">
     <AppHeader class="mb-8" title="Bookmarks" :description="description" />
+    <!-- HomeDitherBackground (rendered in app.vue for this route) measures
+         this to know where to fully fade out — same boundary marker used by
+         every other top-level page (/, /topics, /projects, /articles). -->
+    <div data-dither-boundary></div>
     <ul class="space-y-5">
       <li v-for="bookmark in bookmarks" :key="bookmark.id">
         <a

--- a/app/pages/topics/[slug].vue
+++ b/app/pages/topics/[slug].vue
@@ -30,6 +30,12 @@
         </p>
       </div>
     </div>
+    <!-- HomeDitherBackground (rendered in app.vue for this route) measures
+         this to know where to fully fade out — same boundary marker used by
+         every other top-level page. Placed after the header block (unlike
+         AppHeader-based pages) since this page has its own custom
+         icon+title header rather than the shared component. -->
+    <div data-dither-boundary></div>
     <ul v-if="filteredArticles.length" class="space-y-8">
       <li v-for="(article, id) in filteredArticles" :key="id">
         <AppArticleCard :article="article" />


### PR DESCRIPTION
## What
The animated terracotta dither hero (\`HomeDitherBackground\`) was only rendered on \`/\`, \`/topics\`, and \`/projects\` via an explicit allowlist. Every other page — \`/bookmarks\`, \`/articles\`, and individual \`/topics/[slug]\` pages — had no hero at all, making navigation between pages feel visually inconsistent (per feedback: "the transition between Topics and Projects is very nice, I want this to be the same between all of the pages").

Flipped the logic in \`app.vue\` from an allowlist to a denylist of one: the hero now shows on every route except \`/articles/[slug]\` (individual article posts), which intentionally keep their own per-article cover-image-derived background (\`AppArticleDitherBackground\`) — that's a distinct, deliberate visual for long-form content, not an oversight.

Added the \`[data-dither-boundary]\` marker (used by the canvas to know where to stop fading) to the three pages that didn't have one yet: \`/bookmarks\`, \`/articles\`, \`/topics/[slug]\`.

## Verification
- \`npm run generate\` — clean build, 48 routes, no errors.
- Visually confirmed via local preview + headless screenshots that the hero renders and fades correctly on \`/bookmarks\`, \`/articles\`, and a sample \`/topics/[slug]\` page, consistent with the existing \`/\`, \`/topics\`, \`/projects\` treatment.
- Confirmed article post pages (\`/articles/[slug]\`) are unaffected and still use their own cover-image background.

🤖 Generated by Hermes